### PR TITLE
Policy change process proposal

### DIFF
--- a/policies/policy-change-process.md
+++ b/policies/policy-change-process.md
@@ -59,7 +59,7 @@ other than typo fixes or minor formatting changes after that.
 The policy change is approved by means of a regular OTC vote. If the vote
 passes, the policy change is approved, otherwise it is rejected.
 
-Approval is marked by labelling the pull request with the `Approved` label.
+Approval is marked by labelling the pull request with the `Accepted` label.
 
 Rejection is marked by labelling the pull request with the `Rejected` label
 and closing the pull request without merging.

--- a/policies/policy-change-process.md
+++ b/policies/policy-change-process.md
@@ -1,41 +1,42 @@
 Policy on Proposing Technical Policy Changes
 ============================================
 
-This policy represents the way how any additions or changes to the existing
+This policy represents the way that any additions or changes to the existing
 policies are proposed, edited, finalized, and approved.
 
 Policy Change Proposal
 ----------------------
 
 The policy changes or additions are submitted as pull requests in the
-technical-policies repository on GitHub OpenSSL project.
+technical-policies repository on GitHub OpenSSL project. Anyone with
+GitHub account can submit a policy change proposal pull request.
 
-Each policy is placed in an individual file in the MarkDown format in the
+Each policy is placed in an individual file in Markdown format in the
 policies subdirectory.
 
 Any policy change proposal can modify any number of policies as required.
 
 Any policy change proposal SHOULD have a single topic.
 
-The description of the pull request SHOULD provide overview of the changes
+The description of the pull request SHOULD provide an overview of the changes
 and the reasons why the change is proposed.
 
-After the pull request is created the author MUST announce the policy
+After the pull request has been created the author MUST announce the policy
 change proposal on the openssl-project mailing list.
 
-The Editorial Process
+The Review Process
 ---------------------
 
-Adjustments of the change proposal happen via the normal GitHub pull request
+Adjustments to the change proposal happen via the normal GitHub pull request
 review interaction. The pull request MUST be opened for at least two weeks
 after the initial announcement of the change proposal.
 
 The OTC SHOULD discuss the proposal during a meeting.
 
-The OTC SHOULD seek for consensus when finalizing the policy change however
+The OTC SHOULD seek consensus when finalizing the policy change however
 it is not an absolute requirement.
 
-The editorial process is fully public in the sense that anyone can add
+The review process is fully public in the sense that anyone can add
 comments to the pull request and see comments made by others.
 
 Withdrawal
@@ -44,15 +45,20 @@ Withdrawal
 To withdraw the change the submitter of the pull request just closes the
 pull request.
 
-Approval
---------
+The Approval Process
+--------------------
+
+When there are no further changes proposed on the pull request and the
+minimum time for which it must be open passes the pull request is marked
+with the `Ready To Vote` label. The pull request is frozen for any changes
+other than typo fixes or minor formatting changes after that.
 
 The policy change is approved by means of a regular OTC vote. If the vote
 passes, the policy change is approved, otherwise it is rejected.
 
-Approval is marked by labelling the pull request with `Approved` label.
+Approval is marked by labelling the pull request with the `Approved` label.
 
-Rejection is marked by labelling the pull request with `Rejected` label
+Rejection is marked by labelling the pull request with the `Rejected` label
 and closing the pull request without merging.
 
 If the policy change is approved, the pull request is merged to the

--- a/policies/policy-change-process.md
+++ b/policies/policy-change-process.md
@@ -10,7 +10,6 @@ Policy Change Proposal
 The policy changes or additions are submitted as pull requests in the
 technical-policies repository on GitHub OpenSSL project. Anyone with
 GitHub account can submit a policy change proposal pull request.
-
 Each policy is placed in an individual file in Markdown format in the
 policies subdirectory.
 
@@ -26,6 +25,9 @@ change proposal on the openssl-project mailing list.
 
 The Review Process
 ---------------------
+
+If the submitter is not a member of OTC, an OTC member is selected to watch
+over the review process and propose the final approval vote.
 
 Adjustments to the change proposal happen via the normal GitHub pull request
 review interaction. The pull request MUST be opened for at least two weeks

--- a/policies/policy-change-process.md
+++ b/policies/policy-change-process.md
@@ -1,10 +1,10 @@
-Policy change process policy
-============================
+Policy on Proposing Technical Policy Changes
+============================================
 
 This policy represents the way how any additions or changes to the existing
 policies are proposed, edited, finalized, and approved.
 
-Policy change proposal
+Policy Change Proposal
 ----------------------
 
 The policy changes or additions are submitted as pull requests in the
@@ -20,15 +20,15 @@ Any policy change proposal SHOULD have a single topic.
 The description of the pull request SHOULD provide overview of the changes
 and the reasons why the change is proposed.
 
-After the pull request is created the author SHOULD announce the policy
+After the pull request is created the author MUST announce the policy
 change proposal on the openssl-project mailing list.
 
-The editorial process
+The Editorial Process
 ---------------------
 
-Adjustments of the change proposal happens via the normal GitHub pull request
+Adjustments of the change proposal happen via the normal GitHub pull request
 review interaction. The pull request MUST be opened for at least two weeks
-after the initial announce of the change proposal.
+after the initial announcement of the change proposal.
 
 The OTC SHOULD discuss the proposal during a meeting.
 
@@ -48,7 +48,7 @@ Approval
 --------
 
 The policy change is approved by means of a regular OTC vote. If the vote
-passes, the policy change is approved, rejected otherwise.
+passes, the policy change is approved, otherwise it is rejected.
 
 Approval is marked by labelling the pull request with `Approved` label.
 

--- a/policies/policy-change-process.md
+++ b/policies/policy-change-process.md
@@ -10,6 +10,7 @@ Policy Change Proposal
 The policy changes or additions are submitted as pull requests in the
 technical-policies repository on GitHub OpenSSL project. Anyone with
 GitHub account can submit a policy change proposal pull request.
+
 Each policy is placed in an individual file in Markdown format in the
 policies subdirectory.
 

--- a/policies/policy-change-process.md
+++ b/policies/policy-change-process.md
@@ -9,7 +9,7 @@ Policy Change Proposal
 
 The policy changes or additions are submitted as pull requests in the
 technical-policies repository on GitHub OpenSSL project. Anyone with
-GitHub account can submit a policy change proposal pull request.
+a GitHub account can submit a policy change proposal pull request.
 
 Each policy is placed in an individual file in Markdown format in the
 policies subdirectory.

--- a/policies/policy-change-process.md
+++ b/policies/policy-change-process.md
@@ -1,0 +1,59 @@
+Policy change process policy
+============================
+
+This policy represents the way how any additions or changes to the existing
+policies are proposed, edited, finalized, and approved.
+
+Policy change proposal
+----------------------
+
+The policy changes or additions are submitted as pull requests in the
+technical-policies repository on GitHub OpenSSL project.
+
+Each policy is placed in an individual file in the MarkDown format in the
+policies subdirectory.
+
+Any policy change proposal can modify any number of policies as required.
+
+Any policy change proposal SHOULD have a single topic.
+
+The description of the pull request SHOULD provide overview of the changes
+and the reasons why the change is proposed.
+
+After the pull request is created the author SHOULD announce the policy
+change proposal on the openssl-project mailing list.
+
+The editorial process
+---------------------
+
+Adjustments of the change proposal happens via the normal GitHub pull request
+review interaction. The pull request MUST be opened for at least two weeks
+after the initial announce of the change proposal.
+
+The OTC SHOULD discuss the proposal during a meeting.
+
+The OTC SHOULD seek for consensus when finalizing the policy change however
+it is not an absolute requirement.
+
+The editorial process is fully public in the sense that anyone can add
+comments to the pull request and see comments made by others.
+
+Withdrawal
+----------
+
+To withdraw the change the submitter of the pull request just closes the
+pull request.
+
+Approval
+--------
+
+The policy change is approved by means of a regular OTC vote. If the vote
+passes, the policy change is approved, rejected otherwise.
+
+Approval is marked by labelling the pull request with `Approved` label.
+
+Rejection is marked by labelling the pull request with `Rejected` label
+and closing the pull request without merging.
+
+If the policy change is approved, the pull request is merged to the
+master branch of the technical-policies repository.


### PR DESCRIPTION
**Overview**
This proposal provides the process on submitting, editing, finalizing,
and approving the changes of the technical policies of the OpenSSL
project (i.e., those policies governed by OTC).

**The reason**
The reason for the proposal is that OTC intends to formalize its work a little and
to create multiple new technical policies for the project. The process should be open
for external input and review. This proposal tries to achieve these goals.
