### PR TITLE
The Public Voting Procedure of OTC proposal

### DIFF
--- a/policies/voting-procedure.md
+++ b/policies/voting-procedure.md
@@ -2,14 +2,14 @@ The Public Voting Procedure of OTC
 ==================================
 
 The following regulations complement the [OTC Voting Procedures] stated
-in the project bylaws. This policy affects only the public votes.
+in the project bylaws. This policy affects only public votes.
 
 [OTC Voting Procedures]: https://www.openssl.org/policies/omc-bylaws.html#otc-voting
 
 Vote Proposal
 -------------
 
-The votes are proposed in pull requests and issues of technical-policies
+The votes are proposed in pull requests and issues of the technical-policies
 repository on GitHub OpenSSL project.
 
 The vote regarding a policy change proposal is recorded directly in the
@@ -32,7 +32,8 @@ The Final Vote Records
 
 After the vote is closed the proposer of the vote records the final outcome
 and individual member votes in a separate file in the votes subdirectory of
-the repository.
+the repository. The commit with the vote record is pushed directly into
+the master branch of the repository. No pull request is needed.
 
 The file is formatted as follows:
 

--- a/policies/voting-procedure.md
+++ b/policies/voting-procedure.md
@@ -1,0 +1,71 @@
+The Public Voting Procedure of OTC
+==================================
+
+The following regulations complement the [OTC Voting Procedures] stated
+in the project bylaws. This policy affects only the public votes.
+
+[OTC Voting Procedures]: https://www.openssl.org/policies/omc-bylaws.html#otc-voting
+
+Vote Proposal
+-------------
+
+The votes are proposed in pull requests and issues of technical-policies
+repository on GitHub OpenSSL project.
+
+The vote regarding a policy change proposal is recorded directly in the
+pull request of the policy change proposal.
+
+Any other votes are recorded as separate issues in the repository.
+
+Casting the Votes
+-----------------
+
+The individual members of OTC cast their votes directly in the issue or
+pull request where the vote was proposed.
+
+When the votes are cast during an OTC meeting, the person responsible for
+taking the meeting minutes or the proposer of the vote copies the votes
+cast during the meeting into the issue.
+
+The Final Vote Records
+----------------------
+
+After the vote is closed the proposer of the vote records the final outcome
+and individual member votes in a separate file in the votes subdirectory of
+the repository.
+
+The file is formatted as follows:
+
+```
+topic: .
+Proposed by .
+Public: yes
+opened: yyyy-mm-dd
+closed: yyyy-mm-dd
+accepted:  yes/no  (for: X, against: Y, abstained: Z, not voted: T)
+
+  OTC Member A  [  ]
+  OTC Member B  [  ]
+  ...
+```
+
+The individual member votes are recorded as `[+1]` a vote in favour, `[-1]`
+a vote against, `[+0]` an abstention with an inclination in favour,
+`[ 0]` a neutral abstention, `[-0]` an abstention with an inclination
+against, and `[  ]` meaning not voted.
+
+The vote files are named `yyyymmdd-vote-short-id.txt` where the `yyyymmdd`
+is the date when the vote was proposed and the `vote-short-id` is a short
+mnemonic identifier of the vote such as `voting-procedure` or `accept-pr-1234`
+or similar.
+
+Closing the Issue
+-----------------
+
+The issue or pull request where the vote was proposed is then labelled with
+the `Accepted` or `Rejected` label based on whether the vote was accepted or
+not.
+
+The issue is then closed. In case the vote is in a pull request for a policy
+change and the vote passed the pull request for the policy change is squashed
+and merged into the repository.

--- a/policies/voting-procedure.md
+++ b/policies/voting-procedure.md
@@ -39,7 +39,7 @@ The file is formatted as follows:
 
 ```
 Topic: .
-Proposed by .
+Proposed by: .
 Issue link: https://github.com/openssl/technical-policies/issues/...
 Public: yes
 Opened: yyyy-mm-dd

--- a/policies/voting-procedure.md
+++ b/policies/voting-procedure.md
@@ -38,12 +38,13 @@ the master branch of the repository. No pull request is needed.
 The file is formatted as follows:
 
 ```
-topic: .
+Topic: .
 Proposed by .
+Issue link: https://github.com/openssl/technical-policies/issues/...
 Public: yes
-opened: yyyy-mm-dd
-closed: yyyy-mm-dd
-accepted:  yes/no  (for: X, against: Y, abstained: Z, not voted: T)
+Opened: yyyy-mm-dd
+Closed: yyyy-mm-dd
+Accepted:  yes/no  (for: X, against: Y, abstained: Z, not voted: T)
 
   OTC Member A  [  ]
   OTC Member B  [  ]


### PR DESCRIPTION
The following regulations complement the [OTC Voting Procedures] stated
in the project bylaws. This policy affects only the public votes.