### PR TITLE
Branch Policy

### DIFF
--- a/policies/branch-policy.md
+++ b/policies/branch-policy.md
@@ -7,11 +7,8 @@ The openssl repository contains the following maintained branches:
 
 - Any type (bug fix, feature, refactoring, ...) of pull requests is allowed.
 - The development of the next minor or major release happens there.
-  Which kind of release it is is defined by OMC at some point after the
-  branch is opened after the previous release was branched.
-  Implicitly it means that any API/ABI breaking changes are not allowed
-  on this branch unless OMC defines the next release will be a major
-  release.
+  API/ABI breaking changes are allowed on this branch only if the next
+  release will be a major release.
 - Any changes merged to this branch must be ported to the future major
   and future minor branches if they are applicable. This can be done by
   directly cherry-picking the changes when merging if there are no conflicts.
@@ -20,7 +17,7 @@ The openssl repository contains the following maintained branches:
 
 ### The supported release branches
 
-- The development of the next patch releases of supported minor releases
+- The development of the next patch releases of supported stable releases
   happens there.
 - According to [stable release update policy] only bug fixes and
   documentation changes are allowed.
@@ -43,6 +40,9 @@ The openssl repository contains the following maintained branches:
 - There might be no future major branch if the currently developed release
   is a major release and there are no changes accepted for a future major
   release yet.
+- All changes specifically targetting this branch instead of the default
+  development branch must be approved by OTC by consensus during
+  a meeting or a formal vote.
 
 ### A future minor branch
 
@@ -61,6 +61,9 @@ The openssl repository contains the following maintained branches:
 - There might be no future minor branch when the expected future release would
   be a major release or there are no changes accepted for a future minor
   release yet.
+- All changes specifically targetting this branch instead of the default
+  development branch must be approved by OTC by consensus during
+  a meeting or a formal vote.
 
 Branch and tag naming
 ---------------------

--- a/policies/branch-policy.md
+++ b/policies/branch-policy.md
@@ -12,7 +12,7 @@ The openssl repository contains the following maintained branches:
   Implicitly it means that any API/ABI breaking changes are not allowed
   on the master branch unless OMC defines the next release will be a major
   release.
-- Any changes merged to the master branch must be ported to the next major
+- Any changes merged to the master branch must be ported to the future major
   and future minor branches if they are applicable. This can be done by
   directly cherry-picking the changes when merging if there are no conflicts.
   By this we must ensure that no features or bug fixes are unintentionally
@@ -20,18 +20,17 @@ The openssl repository contains the following maintained branches:
 
 ### The supported release branches
 
-- Only bug fixes and documentation changes are allowed.
 - The development of the next patch releases of supported minor releases
   happens there.
+- According to [stable release update policy] only bug fixes and
+  documentation changes are allowed.
 - By exception given by OMC also other types of pull requests can be merged.
-- During the final year of support, we do not commit to anything other than
-  security fixes.
 - Bug fix and documentation pull requests must be always merged to the
   latest branch (including the master branch) where the bug or documentation
   deficiency is present. It can be then merged (backported or directly
   cherry-picked) to all older branches where the deficiency is present.
 
-### A next major branch
+### A future major branch
 
 - The development of the next major release happens there. Implicitly it
   means that any API/ABI breaking changes are allowed but OMC can (and
@@ -53,10 +52,10 @@ The openssl repository contains the following maintained branches:
   the minor release.
 - No major refactoring is allowed.
 - Any changes (features, bug-fixes, documentation, ...) done on the future
-  minor branch must be ported or directly cherry-picked to the next major
+  minor branch must be ported or directly cherry-picked to the future major
   branch if applicable.
 - Exceptions are possible for example when we are removing deprecated
-  functionality in the next major branch.
+  functionality in the future major branch.
 - There might be no future minor branch opened at times when the expected
   future release would be a major release.
 
@@ -71,7 +70,7 @@ The existing stable release branches are named `openssl-x.y`.
 As a legacy exception to the rule above, the branch where the development of
 OpenSSL-1.1.1 fix releases is happening is called `OpenSSL_1_1_1-stable`.
 
-Next-major: The branch where the development of the next major release is
+Future-major: The branch where the development of the future major release is
 happening is called `openssl-x.0` where `x` is the next major version number.
 If at some point a decision is made to change the major version, the branch
 is renamed accordingly.
@@ -86,3 +85,5 @@ Release tags: The releases are tagged with tags named `openssl-x.y.z` for stable
 patch releases, `openssl-x.y.0-alphaN` for alpha releases, and
 `openssl-x.y.0-betaN` for beta releases. As a legacy exception the fix releases
 of OpenSSL-1.1.1 are named `OpenSSL_1_1_1<fix-letter(s)>`.
+
+[stable release update policy]: https://github.com/openssl/technical-policies/blob/master/policies/stable-release-updates.md

--- a/policies/branch-policy.md
+++ b/policies/branch-policy.md
@@ -3,16 +3,16 @@ Branch Policy
 
 The openssl repository contains the following maintained branches:
 
-### The master branch
+### The default development branch
 
 - Any type (bug fix, feature, refactoring, ...) of pull requests is allowed.
 - The development of the next minor or major release happens there.
   Which kind of release it is is defined by OMC at some point after the
-  master branch is opened after the previous release was branched.
+  branch is opened after the previous release was branched.
   Implicitly it means that any API/ABI breaking changes are not allowed
-  on the master branch unless OMC defines the next release will be a major
+  on this branch unless OMC defines the next release will be a major
   release.
-- Any changes merged to the master branch must be ported to the future major
+- Any changes merged to this branch must be ported to the future major
   and future minor branches if they are applicable. This can be done by
   directly cherry-picking the changes when merging if there are no conflicts.
   By this we must ensure that no features or bug fixes are unintentionally
@@ -26,27 +26,29 @@ The openssl repository contains the following maintained branches:
   documentation changes are allowed.
 - By exception given by OMC also other types of pull requests can be merged.
 - Bug fix and documentation pull requests must be always merged to the
-  latest branch (including the master branch) where the bug or documentation
-  deficiency is present. It can be then merged (backported or directly
-  cherry-picked) to all older branches where the deficiency is present.
+  latest branch where the bug or documentation deficiency is present including
+  the future major and minor branches.
+  It can be then merged (backported or directly cherry-picked) to all
+  older branches where the deficiency is present.
 
 ### A future major branch
 
-- The development of the next major release happens there. Implicitly it
+- The development of a future major release happens there. Implicitly it
   means that any API/ABI breaking changes are allowed but OMC can (and
   usually will) limit the extent of the breakage allowed.
 - Major features are allowed. Examples of a major feature: A completely
   new implementation of a protocol. New API for pluggable crypto modules.
 - Major refactoring is allowed. Examples of major refactoring: Splitting
   libcrypto into multiple hierarchically dependent libraries.
-- The branch is identical to the master branch in case the next release
-  in development is a major release.
+- There might be no future major branch if the currently developed release
+  is a major release and there are no changes accepted for a future major
+  release yet.
 
 ### A future minor branch
 
 - The development of the minor release that is supposed to be released
-  after the release currently being developed at the master branch happens
-  there.
+  after the release currently being developed at the default development branch
+  happens there.
 - No API/ABI breaking changes are allowed.
 - No major features are allowed unless explicitly acked by OMC as targeted for
   the minor release.
@@ -56,34 +58,40 @@ The openssl repository contains the following maintained branches:
   branch if applicable.
 - Exceptions are possible for example when we are removing deprecated
   functionality in the future major branch.
-- There might be no future minor branch opened at times when the expected
-  future release would be a major release.
+- There might be no future minor branch when the expected future release would
+  be a major release or there are no changes accepted for a future minor
+  release yet.
 
 Branch and tag naming
 ---------------------
 
 The branch where the development of the next release is happening is called
-`master`.
+`openssl-x.y` where `x` is the current major version number and `y` is the
+version number of the release being developed. This is the default branch
+of the repository.
 
-The existing stable release branches are named `openssl-x.y`.
+The existing stable release branches are also named `openssl-x.y`.
 
 As a legacy exception to the rule above, the branch where the development of
 OpenSSL-1.1.1 fix releases is happening is called `OpenSSL_1_1_1-stable`.
 
 Future-major: The branch where the development of the future major release is
 happening is called `openssl-x.0` where `x` is the next major version number.
-If at some point a decision is made to change the major version, the branch
-is renamed accordingly.
 
 Future-minor: The branch where the development of a future minor release is
 happening is called `openssl-x.y` where `x` is the current major version number
 and `y` is the version number of a version that will be released after the
-version currently developed at the master branch. If at some point a decision
-is made to change the future minor version, the branch is renamed accordingly.
+version currently developed at the default development branch.
 
 Release tags: The releases are tagged with tags named `openssl-x.y.z` for stable
 patch releases, `openssl-x.y.0-alphaN` for alpha releases, and
 `openssl-x.y.0-betaN` for beta releases. As a legacy exception the fix releases
 of OpenSSL-1.1.1 are named `OpenSSL_1_1_1<fix-letter(s)>`.
+
+Branch creation
+---------------
+
+The exact times when the future major and minor branches are created are
+undefined by the policy as that is an OMC responsibility to decide.
 
 [stable release update policy]: https://github.com/openssl/technical-policies/blob/master/policies/stable-release-updates.md

--- a/policies/branch-policy.md
+++ b/policies/branch-policy.md
@@ -1,0 +1,88 @@
+Branch Policy
+=============
+
+The openssl repository contains the following maintained branches:
+
+### The master branch
+
+- Any type (bug fix, feature, refactoring, ...) of pull requests is allowed.
+- The development of the next minor or major release happens there.
+  Which kind of release it is is defined by OMC at some point after the
+  master branch is opened after the previous release was branched.
+  Implicitly it means that any API/ABI breaking changes are not allowed
+  on the master branch unless OMC defines the next release will be a major
+  release.
+- Any changes merged to the master branch must be ported to the next major
+  and future minor branches if they are applicable. This can be done by
+  directly cherry-picking the changes when merging if there are no conflicts.
+  By this we must ensure that no features or bug fixes are unintentionally
+  lost in future major or minor releases.
+
+### The supported release branches
+
+- Only bug fixes and documentation changes are allowed.
+- The development of the next patch releases of supported minor releases
+  happens there.
+- By exception given by OMC also other types of pull requests can be merged.
+- During the final year of support, we do not commit to anything other than
+  security fixes.
+- Bug fix and documentation pull requests must be always merged to the
+  latest branch (including the master branch) where the bug or documentation
+  deficiency is present. It can be then merged (backported or directly
+  cherry-picked) to all older branches where the deficiency is present.
+
+### A next major branch
+
+- The development of the next major release happens there. Implicitly it
+  means that any API/ABI breaking changes are allowed but OMC can (and
+  usually will) limit the extent of the breakage allowed.
+- Major features are allowed. Examples of a major feature: A completely
+  new implementation of a protocol. New API for pluggable crypto modules.
+- Major refactoring is allowed. Examples of major refactoring: Splitting
+  libcrypto into multiple hierarchically dependent libraries.
+- The branch is identical to the master branch in case the next release
+  in development is a major release.
+
+### A future minor branch
+
+- The development of the minor release that is supposed to be released
+  after the release currently being developed at the master branch happens
+  there.
+- No API/ABI breaking changes are allowed.
+- No major features are allowed unless explicitly acked by OMC as targeted for
+  the minor release.
+- No major refactoring is allowed.
+- Any changes (features, bug-fixes, documentation, ...) done on the future
+  minor branch must be ported or directly cherry-picked to the next major
+  branch if applicable.
+- Exceptions are possible for example when we are removing deprecated
+  functionality in the next major branch.
+- There might be no future minor branch opened at times when the expected
+  future release would be a major release.
+
+Branch and tag naming
+---------------------
+
+The branch where the development of the next release is happening is called
+`master`.
+
+The existing stable release branches are named `openssl-x.y`.
+
+As a legacy exception to the rule above, the branch where the development of
+OpenSSL-1.1.1 fix releases is happening is called `OpenSSL_1_1_1-stable`.
+
+Next-major: The branch where the development of the next major release is
+happening is called `openssl-x.0` where `x` is the next major version number.
+If at some point a decision is made to change the major version, the branch
+is renamed accordingly.
+
+Future-minor: The branch where the development of a future minor release is
+happening is called `openssl-x.y` where `x` is the current major version number
+and `y` is the version number of a version that will be released after the
+version currently developed at the master branch. If at some point a decision
+is made to change the future minor version, the branch is renamed accordingly.
+
+Release tags: The releases are tagged with tags named `openssl-x.y.z` for stable
+patch releases, `openssl-x.y.0-alphaN` for alpha releases, and
+`openssl-x.y.0-betaN` for beta releases. As a legacy exception the fix releases
+of OpenSSL-1.1.1 are named `OpenSSL_1_1_1<fix-letter(s)>`.


### PR DESCRIPTION
This is a draft of the branch policy for starting the discussion. There are two additional branches - a **future major branch** and a **future minor branch**.

This should allow for merging PRs that would destabilize development of the next release that is currently in works. I.E. these two branches provide a staging area for patches that we want in future releases being it either a major or minor release based on whether the change involves API breakage or not.