### PR TITLE
Add Policy on API compatibility in minor releases

### DIFF
--- a/policies/api-compat.md
+++ b/policies/api-compat.md
@@ -1,0 +1,15 @@
+Policy on API compatibility in minor releases
+=============================================
+
+**No changes in existing public API functions and data are allowed.**
+
+Only API additions are allowed in minor releases.
+
+Although there might be some kinds of changes that are ABI compatible such
+as constification of parameters, changing a return value type from void
+to int to be able to indicate an error in the call, or changes of an API
+call from a macro to a function, these kinds of changes are allowed only in
+major releases.
+
+If necessary, a new API call can be added to implement the required changes in
+minor releases.

--- a/policies/api-compat.md
+++ b/policies/api-compat.md
@@ -1,6 +1,11 @@
 Policy on API compatibility in minor releases
 =============================================
 
+Public API of the OpenSSL libraries is defined as functions, macros, data
+structure declarations, typedefs, and data variables in header files in the
+`include/openssl` subdirectory of the source tree and `include/openssl`
+subdirectory of the build tree.
+
 **No changes to existing public API functions and data are permitted.** This
 includes, but is not limited to:
 

--- a/policies/api-compat.md
+++ b/policies/api-compat.md
@@ -1,15 +1,19 @@
 Policy on API compatibility in minor releases
 =============================================
 
-**No changes in existing public API functions and data are allowed.**
+**No changes to existing public API functions and data are permitted.** This
+includes, but is not limited to:
+
+- constification of arguments;
+- changing `void` returns to `int` returns;
+- changing a macro to a function and
+- corrections of spelling.
 
 Only API additions are allowed in minor releases.
 
-Although there might be some kinds of changes that are ABI compatible such
-as constification of parameters, changing a return value type from void
-to int to be able to indicate an error in the call, or changes of an API
-call from a macro to a function, these kinds of changes are allowed only in
-major releases.
+Although the changes as listed above might be regarded as ABI compatible, they
+cause various possible breakage when building applications depending on these
+APIs and thus they are not allowed in minor releases.
 
 If necessary, a new API call can be added to implement the required changes in
 minor releases.


### PR DESCRIPTION
This policy disallows all API changes in existing public API functions
and data in minor releases. Only API additions are allowed.