### PR TITLE
Make the voting policy match reality

### DIFF
--- a/policies/voting-procedure.md
+++ b/policies/voting-procedure.md
@@ -56,7 +56,7 @@ a vote against, `[+0]` an abstention with an inclination in favour,
 `[ 0]` a neutral abstention, `[-0]` an abstention with an inclination
 against, and `[  ]` meaning not voted.
 
-The vote files are named `yyyymmdd-vote-short-id.txt` where the `yyyymmdd`
+The vote files are named `vote-yyyymmdd-vote-short-id.txt` where the `yyyymmdd`
 is the date when the vote was proposed and the `vote-short-id` is a short
 mnemonic identifier of the vote such as `voting-procedure` or `accept-pr-1234`
 or similar.


### PR DESCRIPTION
The filenames for votes specified by the policy, and the filenames actually
used are slightly different. Bring the policy into line with reality.