### PR TITLE
code style: public functions should check their arguments

### DIFF
--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -323,9 +323,9 @@ because it is a simple way to add valuable information for the reader.
 The name in the prototype declaration should match the name in the function
 definition.
 
-### Chapter 6.1: Checking function aguments
+### Chapter 6.1: Checking function arguments
 
-A _public_ function should verify that it's arguments are sensible.
+A _public_ function should verify that its arguments are sensible.
 This includes, but is not limited to, verifying that:
 - non-optional pointer arguments are not NULL and
 - numeric arguments are within expected ranges.

--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -323,7 +323,16 @@ because it is a simple way to add valuable information for the reader.
 The name in the prototype declaration should match the name in the function
 definition.
 
-### Chapter 6.1: Extending existing functions
+### Chapter 6.1: Checking function aguments
+
+A _public_ function should verify that it's arguments are sensible.
+This includes, but is not limited to, verifying that:
+- non-optional pointer arguments are not NULL and
+- numeric arguments are within expected ranges.
+
+Where an argument is not sensible, an error should be returned.
+
+### Chapter 6.2: Extending existing functions
 
 From time to time it is necessary to extend an existing function. Typically this
 will mean adding additional arguments, but it may also include removal of some.

--- a/policies/stable-release-updates.md
+++ b/policies/stable-release-updates.md
@@ -50,6 +50,9 @@ A **bug fix** is **not**:
 - memory usage reduction
 - replacement implementation of algorithms
 - refactoring
+- addressing deviations from the [coding style policy].
+
+[coding style policy]: https://github.com/openssl/technical-policies/blob/master/policies/coding-style.md
 
 An **end-user documentation** is:
 

--- a/votes/vote-20220210-public-functions-check-args.txt
+++ b/votes/vote-20220210-public-functions-check-args.txt
@@ -1,0 +1,19 @@
+Topic: Public functions should check their arguments as of commit 1e37b5f.
+       This will become an official OTC policy.
+Proposed by: Pauli
+Issue link: https://github.com/openssl/technical-policies/pull/21
+Public: yes
+Opened: 2022-02-10
+Closed: 2022-02-17
+Accepted:  yes  (for: 8, against: 0, abstained: 1, not voted: 1)
+
+  Dmitry     [+1]
+  Matt       [+1]
+  Pauli      [+1]
+  Tim        [+1]
+  Richard    [  ]
+  Shane      [+1]
+  Tomas      [ 0]
+  Kurt       [+1]
+  Matthias   [+1]
+  Nicola     [+1]


### PR DESCRIPTION
Public functions should include basic sanity checks of their arguments.