### PR TITLE
Clarify the definition of stable release, and add definition of patch release

### DIFF
--- a/policies/stable-release-updates.md
+++ b/policies/stable-release-updates.md
@@ -6,8 +6,10 @@ This policy covers allowed changes on stable release branches.
 Definitions
 -----------
 
-A **stable release** is a patch release from an existing supported minor
-release branch.
+A **stable release** is a series beginning with a major or minor release that
+is not a pre-release, and all its updates.
+
+A **patch release** is an update within a stable release.
 
 A **public interface** is any function, structure or macro declared in a public
 header file.

--- a/votes/vote-20220304-clarify-release-terminology.txt
+++ b/votes/vote-20220304-clarify-release-terminology.txt
@@ -1,0 +1,17 @@
+topic: Clarify the definition of stable release, and add definition of patch release
+Proposed by Richard
+Public: yes
+opened: 2022-03-04
+closed: 2022-03-23
+accepted:  yes  (for: 4, against: 0, abstained: 3, not voted: 3)
+
+  Dmitry     [  ]
+  Matt       [+1]
+  Pauli      [ 0]
+  Tim        [+1]
+  Richard    [+1]
+  Shane      [+0]
+  Tomas      [  ]
+  Kurt       [  ]
+  Matthias   [+1]
+  Nicola     [ 0]


### PR DESCRIPTION
The language used made it unclear if x.y.0 would be considered a
stable release.  Furthermore, the term "patch release" is used without
definition in this document.
