### PR TITLE
coding-style.md: add various rules for writing C expressions

### DIFF
--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -593,39 +593,40 @@ used on and therefore should be avoided.
 
 ## Chapter 15: Expressions
 
-Avoid needless parentheses.<br/>
+Avoid needless parentheses.
 For example, do not write
 ```c
     if ((p == NULL) && (!f(((2 * x) + y) == (z++))))
- ```
+```
 but
 ```c
     if (p == NULL && !f(2 * x + y == z++)).
 ```
 
-For clarity, always put parentheses when mixing `&&` and `||` operations.<br/>
+For clarity, always put parentheses when mixing `&&` and `||` operations.
 For example,
- ```c
+```c
     if ((a && b) || c)
- ```
+```
 
-Put parentheses around macro bodies that can be used as expressions.<br/>
+Put parentheses around macro bodies that can be used as expressions.
+
 Put parentheses around uses of macro arguments
-(unless they are passed on as-is to a further macro or function).<br/>
+(unless they are passed on as-is to a further macro or function).
 For example,
- ```c
+```c
 #define SQUARE(a) ((a) * (a))
 ```
 
 In comparisons with constants (including `NULL`)
-place the constant on the right-hand side of the comparison operator.<br/>
+place the constant on the right-hand side of the comparison operator.
 For example,
 ```c
     while (i++ < 10 && p != NULL)
 ```
 
 Do not use implicit checks for
-numbers (not) being `0` or pointers (not) being `NULL`.<br/>
+numbers (not) being `0` or pointers (not) being `NULL`.
 For example, do not write
 ```c
     if (i)
@@ -644,7 +645,7 @@ but do this instead:
 If you need to break an expression into multiple lines,
 make the line break before an operator, not after.
 It is preferred that such a line break is made
-before as low priority an operator as possible.<br>
+before as low priority an operator as possible.
 Examples:
 
 * not this:
@@ -664,9 +665,8 @@ Examples:
       == PRETTY_DARN_LONG_MACRO_NAME)
   ```
 
-Whan appearing at the beginning of a line,
-the binary logical operators `&&` and `||`
-may get an extra indentation (+4 characters).<br/>
+When appearing at the beginning of a line,
+operators may get an extra indentation (+4 characters).
 For example,
 ```c
     if (long_condition_expression_1

--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -255,7 +255,7 @@ variable that is used to hold a temporary value.
 
 If you are afraid that someone might mix up your local variable names,
 perhaps the function is too long;
-see the [chapter on functions](#user-content-chapter-6-functions).
+see the [chapter on functions](#chapter-6-functions).
 
 ## Chapter 5: Typedefs
 
@@ -623,7 +623,7 @@ For example,
 ```
 
 Regarding parentheses in macro definitions see the
-[chapter on macros](#user-content-chapter-9-macros-and-enums).
+[chapter on macros](#chapter-9-macros-and-enums).
 
 In comparisons with constants (including `NULL` and other constant macros)
 place the constant on the right-hand side of the comparison operator.

--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -254,7 +254,8 @@ being mis-understood. Similarly, _tmp_ can be just about any type of
 variable that is used to hold a temporary value.
 
 If you are afraid that someone might mix up your local variable names,
-perhaps the function is too long; see Chapter 6.
+perhaps the function is too long;
+see the [chapter on functions](#user-content-chapter-6-functions).
 
 ## Chapter 5: Typedefs
 
@@ -469,16 +470,25 @@ Do not write macros that are l-values:
 
 This will cause problems if, e.g., FOO becomes an inline function.
 
-Be careful of precedence. Macros defining constants using expressions
-must enclose the expression in parentheses:
+Be careful of precedence.
+Macros defining an expression must enclose the expression in parentheses
+unless the expression is a literal or a function application:
 
 ```c
-    #define CONSTANT 0x4000
-    #define CONSTEXP (CONSTANT | 3)
+    #define SOME_LITERAL 0x4000
+    #define CONSTEXP (SOME_LITERAL | 3)
+    #define CONSTFUN foo(0, CONSTEXP)
 ```
 
-Beware of similar issues with macros using parameters. The [GNU cpp manual][8]
-deals with macros exhaustively.
+Beware of similar issues with macros using parameters.
+Put parentheses around uses of macro arguments
+unless they are passed on as-is to a further macro or function.
+For example,
+```c
+#define MACRO(a,b) ((a) * func(a, b))
+```
+
+The [GNU cpp manual][8] deals with macros exhaustively.
 
 ## Chapter 10: Allocating memory
 
@@ -512,7 +522,7 @@ subject to these rules. Generally they indicate failure by returning some
 out-of-range result. The simplest example is functions that return pointers;
 they return NULL to report failure.
 
-## Chapter 12:  Editor modelines
+## Chapter 12: Editor modelines
 
 Some editors can interpret configuration information embedded in source
 files, indicated with special markers. For example, emacs interprets
@@ -542,7 +552,7 @@ This includes markers for indentation and mode configuration. People may
 use their own custom mode, or may have some other magic method for making
 indentation work correctly.
 
-## Chapter 13:  Processor-specific code
+## Chapter 13: Processor-specific code
 
 In OpenSSL's case the only reason to resort to processor-specific code
 is for performance. As it still exists in a general platform-independent
@@ -584,7 +594,7 @@ less complicated than coding pure assembly, and it doesn't provide the
 same performance guarantee across different micro-architecture. Nor is
 it portable enough to meet our multi-platform support goals.
 
-## Chapter 14:  Portability
+## Chapter 14: Portability
 
 To maximise portability the version of C defined in ISO/IEC 9899:1990
 should be used. This is more commonly referred to as C90. ISO/IEC 9899:1999
@@ -593,7 +603,7 @@ used on and therefore should be avoided.
 
 ## Chapter 15: Expressions
 
-Avoid needless parentheses.
+Avoid needless parentheses as far as reasonable.
 For example, do not write
 ```c
     if ((p == NULL) && (!f(((2 * x) + y) == (z++))))
@@ -603,22 +613,19 @@ but
     if (p == NULL && !f(2 * x + y == z++)).
 ```
 
-For clarity, always put parentheses when mixing `&&` and `||` operations.
+For clarity, always put parentheses when mixing `&&` and `||` operations,
+comparison operators like `<=` and `==`, and bitwise operators.
 For example,
 ```c
     if ((a && b) || c)
+    if ((a <= b) == ((c >= d) != (e < f)))
+    x = (a & b) ^ (c | d)
 ```
 
-Put parentheses around macro bodies that can be used as expressions.
+Regarding parentheses in macro definitions see the
+[chapter on macros](#user-content-chapter-9-macros-and-enums).
 
-Put parentheses around uses of macro arguments
-(unless they are passed on as-is to a further macro or function).
-For example,
-```c
-#define SQUARE(a) ((a) * (a))
-```
-
-In comparisons with constants (including `NULL`)
+In comparisons with constants (including `NULL` and other constant macros)
 place the constant on the right-hand side of the comparison operator.
 For example,
 ```c
@@ -666,7 +673,7 @@ Examples:
   ```
 
 When appearing at the beginning of a line,
-operators may get an extra indentation (+4 characters).
+operators can, but do not have to, get an extra indentation (+ 4 characters).
 For example,
 ```c
     if (long_condition_expression_1

--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -614,7 +614,7 @@ Put parentheses around uses of macro arguments
 (unless they are passed on as-is to a further macro or function).<br/>
 For example,
  ```c
-#define SQUARE(a) ((a) * (b))
+#define SQUARE(a) ((a) * (a))
 ```
 
 In comparisons with constants (including `NULL`)
@@ -641,9 +641,32 @@ but do this instead:
     if ((p = BN_new()) == NULL)
 ```
 
-Do not place binary logical operators `&&` and `||` at the end of a line
-but put them at the beginning of the following line.<br/>
-They may get an extra indentation (+4 characters).<br/>
+If you need to break an expression into multiple lines,
+make the line break before an operator, not after.
+It is preferred that such a line break is made
+before as low priority an operator as possible.<br>
+Examples:
+
+* not this:
+  ```c
+  if (somewhat_long_function_name(foo) == 1 && a_long_variable_name
+      == 2)
+  ```
+  but rather:
+  ```c
+  if (somewhat_long_function_name(foo) == 1
+      && a_long_variable_name == 2)
+  ```
+
+* This is, however, still ok:
+  ```c
+  if (this_thing->this_freakishly_super_long_name(somewhat_long_name, 3)
+      == PRETTY_DARN_LONG_MACRO_NAME)
+  ```
+
+Whan appearing at the beginning of a line,
+the binary logical operators `&&` and `||`
+may get an extra indentation (+4 characters).<br/>
 For example,
 ```c
     if (long_condition_expression_1

--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -591,21 +591,66 @@ should be used. This is more commonly referred to as C90. ISO/IEC 9899:1999
 (also known as C99) is not supported on some platforms that OpenSSL is
 used on and therefore should be avoided.
 
-## Chapter 15: Miscellaneous
+## Chapter 15: Expressions
 
-Do not use `!` to check if a pointer is NULL, or to see if a str...cmp
-function found a match.  For example, these are wrong:
-
+Avoid needless parentheses.<br/>
+For example, do not write
 ```c
-    if (!(p = BN_new())) ...
-    if (!strcmp(a, "FOO")) ...
+    if ((p == NULL) && (!f(((2 * x) + y) == (z++))))
+ ```
+but
+```c
+    if (p == NULL && !f(2 * x + y == z++)).
 ```
 
-Do this instead:
+For clarity, always put parentheses when mixing `&&` and `||` operations.<br/>
+For example,
+ ```c
+    if ((a && b) || c)
+ ```
 
+Put parentheses around macro bodies that can be used as expressions.<br/>
+Put parentheses around uses of macro arguments
+(unless they are passed on as-is to a further macro or function).<br/>
+For example,
+ ```c
+#define SQUARE(a) ((a) * (b))
+```
+
+In comparisons with constants (including `NULL`)
+place the constant on the right-hand side of the comparison operator.<br/>
+For example,
 ```c
-    if ((p = BN_new()) == NULL)...
-    if (strcmp(a, "FOO") == 0) ...
+    while (i++ < 10 && p != NULL)
+```
+
+Do not use implicit checks for
+numbers (not) being `0` or pointers (not) being `NULL`.<br/>
+For example, do not write
+```c
+    if (i)
+    if (!(x & MASK))
+    if (!strcmp(a, "FOO"))
+    if (!(p = BN_new()))
+```
+but do this instead:
+```c
+    if (i != 0)
+    if ((x & MASK) == 0)
+    if (strcmp(a, "FOO") == 0)
+    if ((p = BN_new()) == NULL)
+```
+
+Do not place binary logical operators `&&` and `||` at the end of a line
+but put them at the beginning of the following line.<br/>
+They may get an extra indentation (+4 characters).<br/>
+For example,
+```c
+    if (long_condition_expression_1
+            && condition_expression_2) {
+        statement_1;
+        statement_2;
+    }
 ```
 
 ## Chapter 16: References


### PR DESCRIPTION
Add a first chunk of rules, taken from the list of proposed ones collected at https://github.com/openssl/openssl/issues/10725, 
focusing on how (not) to write C expressions. 

This PR significantly generalizes the former **Miscellaneous** section of [policies/coding-style.md](https://github.com/openssl/technical-policies/blob/master/policies/coding-style.md).

This PR only partially fixes https://github.com/openssl/openssl/issues/10725 - as @mattcaswell wrote in https://github.com/openssl/openssl/issues/10725#issuecomment-1085513555:
> I'd suggest any PR target only one or a handful of changes at a time. 