### PR TITLE
Add Release Requirements Policy

### DIFF
--- a/policies/release-requirements.md
+++ b/policies/release-requirements.md
@@ -8,17 +8,17 @@ releases:
 - [alpha] (pre-)releases
 - [beta] (pre-)releases
 
-This policy defines the requirements on the state of the source tree that
-must be met before the release can be done.
+This policy defines the requirements on the state of a branch in the source
+tree that must be met before a release from that branch can be done.
 
 Alpha Pre-releases
 ------------------
 
 As this is just a preview release for testing things that have been worked
-on the development branch of the source code the requirements are minimal.
+on in the development branch, the requirements are minimal.
 
-- The CI must pass on tip of the development branch before the release commits
-  were added to the tree.
+- The CI must pass on the tip of the development branch before the release
+  commits were added to the tree.
 
 Beta Pre-releases
 -----------------

--- a/policies/release-requirements.md
+++ b/policies/release-requirements.md
@@ -6,7 +6,8 @@ releases:
 
 - [alpha] (pre-)releases
 - [beta] (pre-)releases
-- [major] and [minor] releases
+- [major] releases
+- [minor] releases
 - [patch] releases
 
 This policy defines the requirements on the state of a branch in the source
@@ -107,15 +108,15 @@ bug is a regression or not.
 
 In general regressions should be fixed as soon as possible, optimally before
 the next release from the development tree is done. However sometimes that
-might not be reasonably possible or an issue is identified to be a regression
-too short time before the release is planned to be done.
+might not be reasonably possible due to time, resource, or fix complexity
+constraints.
 
 In that case OTC should explicitly acknowledge that the regression is not to be
 fixed before the release is done. That is done by assigning a milestone by
 which the regression must be fixed and the `triaged: OTC evaluated` label.
 
-The triage ideally happens as soon as possible however the triage process can
-be sometimes costly so we aim to have issues triaged no later than 4 days
+The triage ideally happens as soon as possible, however the triage process can
+sometimes be costly, so we aim to have issues triaged no later than 4 days
 after they are reported.
 
 Responsibilities

--- a/policies/release-requirements.md
+++ b/policies/release-requirements.md
@@ -1,12 +1,13 @@
 Release Requirements Policy
 ===========================
 
-The OpenSSL project team creates the following three types of OpenSSL software
+The OpenSSL project team creates the following 6 types of OpenSSL software
 releases:
 
-- [stable] releases
 - [alpha] (pre-)releases
 - [beta] (pre-)releases
+- [major] and [minor] releases
+- [patch] releases
 
 This policy defines the requirements on the state of a branch in the source
 tree that must be met before a release from that branch can be done.
@@ -34,54 +35,66 @@ pre-releases.
   _This applies only to beta releases of a major release as API changes
   are not allowed on minor releases._
 - There are no remaining API additions required for the release.
-- All untriaged issues older than 4 days must be triaged.
-- All issues triaged as regressions on the development branch from which the
-  release is to be done must have a milestone assigned by OTC.
-  _Regressions are considered from the previous stable release. The process
-  of how OTC assigns the milestone is not exactly defined on purpose._
-- All issues or pull requests with beta milestone for the beta release
+- All issues [triaged] as regressions on the development branch from which the
+  release is to be done must have a milestone assigned.
+  _Regressions are considered from the previous stable release or previous
+  beta release._
+- All issues or pull requests with the milestone for the beta release
   are closed.
 - There are no outstanding untriaged Coverity issues.
 - Coveralls coverage has not decreased overall from the previous release.
 - The CI must pass on the tip of the development branch before the release
   commits are added to the tree, including the daily CI builds.
-- The tree must be frozen for at least 4 days. No changes apart from regression
-  or security fixes should be merged during the freeze.
-- For 1 day before the release there should be no changes to ensure the daily
+- The tree must be frozen for at least 3 business days. No changes apart from
+  regression or security fixes should be merged during the freeze.
+- For 2 days before the release there should be no changes to ensure the daily
   CI builds run on the development tree tip.
-- Embargoed security fixes are excepted from the rule above as they cannot
-  be merged to the public tree before the release is being prepared.
 - In case of the first beta release the OTC should explicitly approve
   that the source is ready for a release with a vote.
 
-Stable Releases
----------------
+Major and Minor Releases
+------------------------
 
-For stable releases the requirements are basically the same as the release
-requirements for the beta releases but they are repeated here for clarity.
 As the release comes after the beta releases there is no need to repeat the
 stability requirements as those should be held already by the beta releases.
 
-- All untriaged issues older than 4 days must be triaged.
-- All issues triaged as regressions on the development branch from which the
-  release is to be done must have a milestone assigned by OTC.
-  _Regressions are considered from the previous stable release series and the
-  previous stable release from the branch being released. The process
-  how OTC assigns the milestone is not exactly defined on purpose._
-- All issues or pull requests with milestone for the release are closed.
+- All issues [triaged] as regressions on the development branch from which the
+  release is to be done must have a milestone assigned.
+  _Regressions are considered from the previous stable release series._
+- All issues or pull requests with the milestone for the release are closed.
 - There are no outstanding untriaged Coverity issues.
 - Coveralls coverage has not decreased overall from the previous release from
   the particular development branch.
 - The CI must pass on the tip of the development branch before the release
   commits are added to the tree, including the daily CI builds.
-- The tree must be frozen for at least 4 days. No changes apart from regression
+- The tree must be frozen for at least 7 days. No changes apart from regression
   or security fixes should be merged during the freeze.
-- For 1 day before the release there should be no changes to ensure the daily
+- For 2 days before the release there should be no changes to ensure the daily
+  CI builds run on the development tree tip.
+- The OTC should explicitly approve that the source is ready for a release with
+  a vote.
+
+Patch Releases
+--------------
+
+The patch releases follow a similar process to major and minor releases with
+some simplifications as they are much more frequent and the tree stability
+requirements for the stable development branches should ensure there is
+a minimum amount of regressions in between the patch releases.
+
+- All issues [triaged] as regressions on the development branch from which the
+  release is to be done must have a milestone assigned.
+  _Regressions are considered from the previous minor, major or patch release
+  from the development branch._
+- All issues or pull requests with the milestone for the release are closed.
+- The CI must pass on the tip of the development branch before the release
+  commits are added to the tree, including the daily CI builds.
+- The tree must be frozen for at least 3 business days. No changes apart from
+  regression or security fixes should be merged during the freeze.
+- For 2 days before the release there should be no changes to ensure the daily
   CI builds run on the development tree tip.
 - Embargoed security fixes are excepted from the rule above as they cannot
   be merged to the public tree before the release is being prepared.
-- In case of the first stable release from the development branch the OTC should
-  explicitly approve that the source is ready for a release with a vote.
 
 Triage Process
 --------------
@@ -92,26 +105,33 @@ refactoring, ...) of the issue or pull request. When the triage happens for an
 issue or pull request that is a bug/bug fix, it must be assessed whether the
 bug is a regression or not.
 
-In general regressions are not allowed in stable releases so they should be
-fixed as soon as possible, optimally before the release is done. However
-sometimes that might not be reasonably possible or an issue is identified
-to be a regression later than during the initial triage.
+In general regressions should be fixed as soon as possible, optimally before
+the next release from the development tree is done. However sometimes that
+might not be reasonably possible or an issue is identified to be a regression
+too short time before the release is planned to be done.
 
 In that case OTC should explicitly acknowledge that the regression is not to be
 fixed before the release is done. That is done by assigning a milestone by
 which the regression must be fixed and the `triaged: OTC evaluated` label.
+
+The triage ideally happens as soon as possible however the triage process can
+be sometimes costly so we aim to have issues triaged no later than 4 days
+after they are reported.
 
 Responsibilities
 ----------------
 
 The OTC is responsible to ensure the releases confirm to these requirements.
 How exactly the OTC handles this responsibility is undefined here on purpose
-except for the explicit votes required for the first beta release and the first
-stable release from a particular development branch.
+except for the explicit votes required for the first beta release and the
+major or minor releases.
 
 For example the responsibility to follow the release requirements can be
 delegated by the OTC to the person (or the team) preparing the release.
 
-[stable]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#stable-release
 [alpha]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#alpha-release
 [beta]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#beta-release
+[major]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#major-release
+[minor]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#minor-release
+[patch]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#patch-release
+[triaged]: #triage-process

--- a/policies/release-requirements.md
+++ b/policies/release-requirements.md
@@ -27,7 +27,7 @@ The API and ABI should be stable and the source code should be feature complete
 by the first beta pre-release. The following release requirements apply to beta
 pre-releases.
 
-- The code is functionaly complete in regards to the particular release
+- The code is functionally complete in regards to the particular release
   objectives as set by OMC and OTC.
 - There is no remaining refactoring required by OMC or OTC for the release.
 - There are no remaining API changes required for the release.

--- a/policies/release-requirements.md
+++ b/policies/release-requirements.md
@@ -1,0 +1,91 @@
+Release Requirements Policy
+===========================
+
+The OpenSSL project team creates the following three types of OpenSSL software
+releases:
+
+- [stable] releases
+- [alpha] (pre-)releases
+- [beta] (pre-)releases
+
+This policy defines the requirements on the state of the source tree that
+must be met before the release can be done.
+
+Alpha Pre-releases
+------------------
+
+As this is just a preview release for testing things that have been worked
+on the development branch of the source code the requirements are minimal.
+
+- The CI must pass on tip of the development branch before the release commits
+  were added to the tree.
+
+Beta Pre-releases
+-----------------
+
+The API and ABI should be stable and the source code should be feature complete
+by the first beta pre-release for the stable release. The following release
+requirements apply to beta pre-releases.
+
+- The code is functionaly complete in regards to the particular release
+  objectives as set by OMC and OTC.
+- There is no remaining refactoring required by OMC or OTC for the release.
+- There are no remaining API changes required for the release.
+  _This applies only to beta releases of a major release as API changes
+  are not allowed on minor releases._
+- All untriaged issues must be triaged.
+- All regressions on the development branch from which the
+  release is to be done must have a milestone assigned by OTC.
+  _Regressions are considered from the previous stable release. The process
+  how OTC assigns the milestone is not exactly defined on purpose._
+- All issues or pull requests with beta milestone for the beta release
+  are closed.
+- There is no outstanding untriaged Coverity issue.
+- Coveralls coverage has not decreased overall from the previous release.
+- The CI must pass on tip of the development branch before the release commits
+  were added to the tree, including the daily CI builds.
+- The tree must be frozen at least for one day, which also ensures the daily CI
+  builds run on the development tree tip.
+- In case of the first beta release the OTC should explicitly approve
+  that the source is ready for a release with a vote.
+
+Stable Releases
+---------------
+
+For stable releases the requirements are basically the same as the release
+requirements for the beta releases but they are repeated here for clarity.
+As the release comes after the beta releases there is no need to repeat the
+stability requirements as those should be held already by the beta releases.
+
+- All untriaged issues must be triaged.
+- All regressions on the development branch from which the
+  release is to be done must have a milestone assigned by OTC.
+  _Regressions are considered from the previous stable release. The process
+  how OTC assigns the milestone is not exactly defined on purpose._
+- All issues or pull requests with milestone for the release are closed.
+- There is no outstanding untriaged Coverity issue.
+- Coveralls coverage has not decreased overall from the previous release.
+- The CI must pass on tip of the development branch before the release commits
+  were added to the tree, including the daily CI builds.
+- The tree must be frozen at least for one day, which also ensures the daily CI
+  builds run on the development tree tip.
+- In case of the first stable release from the development branch the OTC should
+  explicitly approve that the source is ready for a release with a vote.
+
+Triage Process
+--------------
+
+The issues and pull requests in GitHub must be assigned a `triaged: *` label by
+an OTC member according to what is the type (feature, bug, documentation,
+refactoring, ...) of the issue or pull request. When the triage happens for an
+issue or pull request that is a bug/bug fix, it must be assessed whether the
+bug is a regression or not. In general regressions are not allowed in stable
+releases so they should be fixed as soon as possible, optimally before the
+release is done. However sometimes that might not be reasonably possible.
+In that case OTC should explicitly acknowledge that the regression is not to be
+fixed before the release is done. That is done by assigning a milestone by
+which the regression must be fixed and the `triaged: OTC evaluated` label.
+
+[stable]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#stable-release
+[alpha]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#alpha-release
+[beta]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#beta-release

--- a/policies/release-requirements.md
+++ b/policies/release-requirements.md
@@ -24,8 +24,8 @@ Beta Pre-releases
 -----------------
 
 The API and ABI should be stable and the source code should be feature complete
-by the first beta pre-release for the stable release. The following release
-requirements apply to beta pre-releases.
+by the first beta pre-release. The following release requirements apply to beta
+pre-releases.
 
 - The code is functionaly complete in regards to the particular release
   objectives as set by OMC and OTC.
@@ -33,17 +33,18 @@ requirements apply to beta pre-releases.
 - There are no remaining API changes required for the release.
   _This applies only to beta releases of a major release as API changes
   are not allowed on minor releases._
-- All untriaged issues must be triaged.
+- There are no remaining API additions required for the release.
+- All untriaged issues older than 2 days must be triaged.
 - All regressions on the development branch from which the
   release is to be done must have a milestone assigned by OTC.
   _Regressions are considered from the previous stable release. The process
   how OTC assigns the milestone is not exactly defined on purpose._
 - All issues or pull requests with beta milestone for the beta release
   are closed.
-- There is no outstanding untriaged Coverity issue.
+- There are no outstanding untriaged Coverity issues.
 - Coveralls coverage has not decreased overall from the previous release.
-- The CI must pass on tip of the development branch before the release commits
-  were added to the tree, including the daily CI builds.
+- The CI must pass on the tip of the development branch before the release
+  commits are added to the tree, including the daily CI builds.
 - The tree must be frozen at least for one day, which also ensures the daily CI
   builds run on the development tree tip.
 - In case of the first beta release the OTC should explicitly approve
@@ -57,16 +58,16 @@ requirements for the beta releases but they are repeated here for clarity.
 As the release comes after the beta releases there is no need to repeat the
 stability requirements as those should be held already by the beta releases.
 
-- All untriaged issues must be triaged.
+- All untriaged issues older than 2 days must be triaged.
 - All regressions on the development branch from which the
   release is to be done must have a milestone assigned by OTC.
   _Regressions are considered from the previous stable release. The process
   how OTC assigns the milestone is not exactly defined on purpose._
 - All issues or pull requests with milestone for the release are closed.
-- There is no outstanding untriaged Coverity issue.
+- There are no outstanding untriaged Coverity issues.
 - Coveralls coverage has not decreased overall from the previous release.
-- The CI must pass on tip of the development branch before the release commits
-  were added to the tree, including the daily CI builds.
+- The CI must pass on the tip of the development branch before the release
+  commits are added to the tree, including the daily CI builds.
 - The tree must be frozen at least for one day, which also ensures the daily CI
   builds run on the development tree tip.
 - In case of the first stable release from the development branch the OTC should

--- a/policies/release-requirements.md
+++ b/policies/release-requirements.md
@@ -122,7 +122,7 @@ after they are reported.
 Responsibilities
 ----------------
 
-The OTC is responsible to ensure the releases confirm to these requirements.
+The OTC is responsible to ensure the releases conform to these requirements.
 How exactly the OTC handles this responsibility is undefined here on purpose
 except for the explicit votes required for the first beta release and the
 major or minor releases.

--- a/policies/release-requirements.md
+++ b/policies/release-requirements.md
@@ -1,7 +1,7 @@
 Release Requirements Policy
 ===========================
 
-The OpenSSL project team creates the following 6 types of OpenSSL software
+The OpenSSL project team creates the following 5 types of OpenSSL software
 releases:
 
 - [alpha] (pre-)releases

--- a/policies/release-requirements.md
+++ b/policies/release-requirements.md
@@ -34,19 +34,23 @@ pre-releases.
   _This applies only to beta releases of a major release as API changes
   are not allowed on minor releases._
 - There are no remaining API additions required for the release.
-- All untriaged issues older than 2 days must be triaged.
-- All regressions on the development branch from which the
+- All untriaged issues older than 4 days must be triaged.
+- All issues triaged as regressions on the development branch from which the
   release is to be done must have a milestone assigned by OTC.
   _Regressions are considered from the previous stable release. The process
-  how OTC assigns the milestone is not exactly defined on purpose._
+  of how OTC assigns the milestone is not exactly defined on purpose._
 - All issues or pull requests with beta milestone for the beta release
   are closed.
 - There are no outstanding untriaged Coverity issues.
 - Coveralls coverage has not decreased overall from the previous release.
 - The CI must pass on the tip of the development branch before the release
   commits are added to the tree, including the daily CI builds.
-- The tree must be frozen at least for one day, which also ensures the daily CI
-  builds run on the development tree tip.
+- The tree must be frozen for at least 4 days. No changes apart from regression
+  or security fixes should be merged during the freeze.
+- For 1 day before the release there should be no changes to ensure the daily
+  CI builds run on the development tree tip.
+- Embargoed security fixes are excepted from the rule above as they cannot
+  be merged to the public tree before the release is being prepared.
 - In case of the first beta release the OTC should explicitly approve
   that the source is ready for a release with a vote.
 
@@ -58,18 +62,24 @@ requirements for the beta releases but they are repeated here for clarity.
 As the release comes after the beta releases there is no need to repeat the
 stability requirements as those should be held already by the beta releases.
 
-- All untriaged issues older than 2 days must be triaged.
-- All regressions on the development branch from which the
+- All untriaged issues older than 4 days must be triaged.
+- All issues triaged as regressions on the development branch from which the
   release is to be done must have a milestone assigned by OTC.
-  _Regressions are considered from the previous stable release. The process
+  _Regressions are considered from the previous stable release series and the
+  previous stable release from the branch being released. The process
   how OTC assigns the milestone is not exactly defined on purpose._
 - All issues or pull requests with milestone for the release are closed.
 - There are no outstanding untriaged Coverity issues.
-- Coveralls coverage has not decreased overall from the previous release.
+- Coveralls coverage has not decreased overall from the previous release from
+  the particular development branch.
 - The CI must pass on the tip of the development branch before the release
   commits are added to the tree, including the daily CI builds.
-- The tree must be frozen at least for one day, which also ensures the daily CI
-  builds run on the development tree tip.
+- The tree must be frozen for at least 4 days. No changes apart from regression
+  or security fixes should be merged during the freeze.
+- For 1 day before the release there should be no changes to ensure the daily
+  CI builds run on the development tree tip.
+- Embargoed security fixes are excepted from the rule above as they cannot
+  be merged to the public tree before the release is being prepared.
 - In case of the first stable release from the development branch the OTC should
   explicitly approve that the source is ready for a release with a vote.
 
@@ -80,12 +90,27 @@ The issues and pull requests in GitHub must be assigned a `triaged: *` label by
 an OTC member according to what is the type (feature, bug, documentation,
 refactoring, ...) of the issue or pull request. When the triage happens for an
 issue or pull request that is a bug/bug fix, it must be assessed whether the
-bug is a regression or not. In general regressions are not allowed in stable
-releases so they should be fixed as soon as possible, optimally before the
-release is done. However sometimes that might not be reasonably possible.
+bug is a regression or not.
+
+In general regressions are not allowed in stable releases so they should be
+fixed as soon as possible, optimally before the release is done. However
+sometimes that might not be reasonably possible or an issue is identified
+to be a regression later than during the initial triage.
+
 In that case OTC should explicitly acknowledge that the regression is not to be
 fixed before the release is done. That is done by assigning a milestone by
 which the regression must be fixed and the `triaged: OTC evaluated` label.
+
+Responsibilities
+----------------
+
+The OTC is responsible to ensure the releases confirm to these requirements.
+How exactly the OTC handles this responsibility is undefined here on purpose
+except for the explicit votes required for the first beta release and the first
+stable release from a particular development branch.
+
+For example the responsibility to follow the release requirements can be
+delegated by the OTC to the person (or the team) preparing the release.
 
 [stable]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#stable-release
 [alpha]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#alpha-release


### PR DESCRIPTION
This adds the policy that covers general requirements that must be met before we create a release (alpha/beta/stable).

It also describes the issue and pull request triage process in short.
