### PR TITLE
coding-style.md: add various rules on spaces, lines, and comments

### DIFF
--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -200,6 +200,9 @@ such as this partial list:
     =  +  -  <  >  *  /  %  |  &  ^  <=  >=  ==  !=  ?  : +=
 ```
 
+Put a space after commas
+and after semicolons in `for` statements, but not in `for(;;)`.
+
 Do not put a space after unary operators:
 
 ```c
@@ -214,11 +217,20 @@ operators or after the prefix increment and decrement unary operators:
     --bar
 ```
 
-Do not put a space around the '.' and "->" structure member operators:
+Do not put a space around the `.` and `->` structure member operators:
 
 ```c
     foo.bar
     foo->bar
+```
+
+* Do not use multiple consecutive spaces
+except for indentation and for multi-line alignment of definitions, e.g.:
+```c
+#define FOO_INVALID  -1   /* invalid or inconsistent arguments */
+#define FOO_INTERNAL 0    /* Internal error, most likely malloc */
+#define FOO_OK       1    /* success */
+#define FOO_GREAT    100  /* some specific outcome */
 ```
 
 Do not leave trailing whitespace at the ends of lines. Some editors with
@@ -231,6 +243,13 @@ Git will warn you about patches that introduce trailing whitespace, and
 can optionally strip the trailing whitespace; however, if applying
 a series of patches, this may make later patches in the series fail by
 changing their context lines.
+
+Avoid empty lines at the beginning or at the end of a file.
+
+Avoid multiple empty lines in a row.
+
+Have an empty line between variable declarations and subsequent statements.
+Do not mix variable declarations and statements.
 
 ## Chapter 4: Naming
 
@@ -389,7 +408,11 @@ For example:
 
 ## Chapter 8: Commenting
 
-Use the classic "/* ... */" comment markers.  Don't use "// ..." markers.
+Use the classic `/*` ... `*/` comment markers.  Don't use `//` ... markers.
+
+Place comments above or to the right of the code they refer to.
+Comments referring to the code line after
+should be indented equally to that code line.
 
 Comments are good, but there is also a danger of over-commenting. NEVER try
 to explain HOW your code works in a comment. It is much better to write
@@ -416,6 +439,8 @@ It's also important to comment data, whether they are basic types or
 derived types. To this end, use just one data declaration per line (no
 commas for multiple data declarations). This leaves you room for a small
 comment on each item, explaining its use.
+
+Make sure that comments do not contain spelling errors.
 
 ## Chapter 9: Macros and Enums
 

--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -248,9 +248,6 @@ Avoid empty lines at the beginning or at the end of a file.
 
 Avoid multiple empty lines in a row.
 
-Have an empty line between variable declarations and subsequent statements.
-Do not mix variable declarations and statements.
-
 ## Chapter 4: Naming
 
 C is a Spartan language, and so should your naming be. Do not use long
@@ -342,6 +339,10 @@ because it is a simple way to add valuable information for the reader.
 The name in the prototype declaration should match the name in the function
 definition.
 
+Separate local variable declarations and subsequent statements by an empty line.
+
+Do not mix local variable declarations and statements.
+
 ### Chapter 6.1: Checking function arguments
 
 A _public_ function should verify that its arguments are sensible.
@@ -408,7 +409,7 @@ For example:
 
 ## Chapter 8: Commenting
 
-Use the classic `/*` ... `*/` comment markers.  Don't use `//` ... markers.
+Use the classic `/* ... */` comment markers.  Don't use `// ...` markers.
 
 Place comments above or to the right of the code they refer to.
 Comments referring to the code line after
@@ -618,7 +619,7 @@ used on and therefore should be avoided.
 
 ## Chapter 15: Miscellaneous
 
-Do not use `!` to check if a pointer is NULL, or to see if a str...cmp
+Do not use `!` to check if a pointer is NULL, or to see if a `str...cmp`
 function found a match.  For example, these are wrong:
 
 ```c

--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -441,8 +441,6 @@ derived types. To this end, use just one data declaration per line (no
 commas for multiple data declarations). This leaves you room for a small
 comment on each item, explaining its use.
 
-Make sure that comments do not contain spelling errors.
-
 ## Chapter 9: Macros and Enums
 
 Names of macros defining constants and labels in enums are in uppercase:

--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -201,7 +201,7 @@ such as this partial list:
 ```
 
 Put a space after commas
-and after semicolons in `for` statements, but not in `for(;;)`.
+and after semicolons in `for` statements, but not in `for (;;)`.
 
 Do not put a space after unary operators:
 
@@ -224,8 +224,8 @@ Do not put a space around the `.` and `->` structure member operators:
     foo->bar
 ```
 
-* Do not use multiple consecutive spaces
-except for indentation and for multi-line alignment of definitions, e.g.:
+Do not use multiple consecutive spaces except in comments,
+for indentation, and for multi-line alignment of definitions, e.g.:
 ```c
 #define FOO_INVALID  -1   /* invalid or inconsistent arguments */
 #define FOO_INTERNAL 0    /* Internal error, most likely malloc */


### PR DESCRIPTION
Add a 2nd chunk of rules, taken from the list of proposed ones collected at https://github.com/openssl/openssl/issues/10725, 
focusing on whitespace.
