### PR TITLE
coding-style.md: add various rules on names

### DIFF
--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -240,9 +240,11 @@ Local variable names should be short, and to the point. If you have
 some random integer loop counter, it should probably be called `i` or `j`.
 Apart from that, avoid single-letter names,
 in particular when they can be visually confusing, such as `I` and `O`.
-Calling a varable `loop_counter` is non-productive, if there is no chance of it
-being mis-understood. Similarly, `tmp` can be just about any type of
-variable that is used to hold a temporary value.
+
+Calling a variable `loop_counter` is non-productive,
+if there is no chance of it being mis-understood.
+Use simple variable names like `tmp` and `name`
+as long as they are non-ambiguous in the given context.
 
 If you are afraid that someone might mix up your local variable names,
 perhaps the function is too long; see Chapter 6.
@@ -268,6 +270,10 @@ Use uppercase prefix like `EVP_` or `OSSL_CMP_` for public (API) symbols.
 Do not encode the type into a name (so-called Hungarian notation).
 
 Align names to terms and wording used in standards and RFCs.
+
+Avoid mixed-case unless needed by other rules.
+Especially never use `FirstCharacterUpperCase`.
+For instance, use `EVP_PKEY_do_something` rather than `EVP_DigestDoSomething`.
 
 Except when otherwise required, avoid mixed-case names.
 

--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -244,8 +244,6 @@ such as `I` and `O`.
 Avoid other single-letter names unless they are telling in the given context.
 For instance, `m` for modulus and `s` for SSL pointers are fine.
 
-Calling a variable `loop_counter` is non-productive,
-if there is no chance of it being mis-understood.
 Use simple variable names like `tmp` and `name`
 as long as they are non-ambiguous in the given context.
 
@@ -270,7 +268,7 @@ unless they are `static` (i.e., local to the source file).
 
 Use uppercase prefix like `EVP_` or `OSSL_CMP_` for public (API) symbols.
 
-Do not encode the type into a name (so-called Hungarian notation).
+Do not encode the type into a name (so-called Hungarian notation, e.g., `int iAge`).
 
 Align names to terms and wording used in standards and RFCs.
 

--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -234,27 +234,40 @@ changing their context lines.
 
 ## Chapter 4: Naming
 
-C is a Spartan language, and so should your naming be. Do not use long
-names like _ThisVariableIsATemporaryCounter_. Use a name like _tmp_, which
-is much easier to write, and not more difficult to understand.
+C is a Spartan language, and so should your naming be.
 
-Except when otherwise required, avoid mixed-case names.
+Local variable names should be short, and to the point. If you have
+some random integer loop counter, it should probably be called `i` or `j`.
+Apart from that, avoid single-letter names,
+in particular when they can be visually confusing, such as `I` and `O`.
+Calling a varable `loop_counter` is non-productive, if there is no chance of it
+being mis-understood. Similarly, `tmp` can be just about any type of
+variable that is used to hold a temporary value.
 
-Do not encode the type into a name (so-called Hungarian notation).
+If you are afraid that someone might mix up your local variable names,
+perhaps the function is too long; see Chapter 6.
 
 Global variables (to be used only if you REALLY need them) need to
 have descriptive names, as do global functions. If you have a function
 that counts the number of active users, you should call that
 _count_active_users()_ or similar, you should NOT call it _cntusr()_.
 
-Local variable names should be short, and to the point. If you have
-some random integer loop counter, it should probably be called _i_.
-Calling it _loop_counter_ is non-productive, if there is no chance of it
-being mis-understood. Similarly, _tmp_ can be just about any type of
-variable that is used to hold a temporary value.
+For getter and setter functions use names containing `get0_` or `get1_`
+(rather than `get_`) and `set0_` or `set1_` (rather than `set_`)
+and `push0_` or `push1_` (rather than `push_`)
+to point out whether the value parameter has aliasing or copying semantics.
 
-If you are afraid that someone might mix up your local variable names,
-perhaps the function is too long; see Chapter 6.
+Use lowercase prefix like `ossl_` for internal symbols.
+
+Use uppercase prefix like `EVP_` or `OSSL_CMP_` for public (API) symbols.
+
+Do not encode the type into a name (so-called Hungarian notation).
+
+Align names to terms and wording used in standards and RFCs.
+
+Except when otherwise required, avoid mixed-case names.
+
+Make sure that names do not contain spelling errors.
 
 ## Chapter 5: Typedefs
 

--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -252,12 +252,15 @@ have descriptive names, as do global functions. If you have a function
 that counts the number of active users, you should call that
 _count_active_users()_ or similar, you should NOT call it _cntusr()_.
 
-For getter and setter functions use names containing `get0_` or `get1_`
+For getter functions returning pointers
+and functions setting a pointer given as a parameter,
+use names containing `get0_` or `get1_`
 (rather than `get_`) and `set0_` or `set1_` (rather than `set_`)
 and `push0_` or `push1_` (rather than `push_`)
 to point out whether the value parameter has aliasing or copying semantics.
 
-Use lowercase prefix like `ossl_` for internal symbols.
+Use lowercase prefix like `ossl_` for internal symbols
+unless they are `static` (i.e., local to the source file).
 
 Use uppercase prefix like `EVP_` or `OSSL_CMP_` for public (API) symbols.
 

--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -238,8 +238,11 @@ C is a Spartan language, and so should your naming be.
 
 Local variable names should be short, and to the point. If you have
 some random integer loop counter, it should probably be called `i` or `j`.
-Apart from that, avoid single-letter names,
-in particular when they can be visually confusing, such as `I` and `O`.
+
+Avoid single-letter names when they can be visually confusing,
+such as `I` and `O`.
+Avoid other single-letter names unless they are telling in the given context.
+For instance, `m` for modulus and `s` for SSL pointers are fine.
 
 Calling a variable `loop_counter` is non-productive,
 if there is no chance of it being mis-understood.
@@ -274,8 +277,6 @@ Align names to terms and wording used in standards and RFCs.
 Avoid mixed-case unless needed by other rules.
 Especially never use `FirstCharacterUpperCase`.
 For instance, use `EVP_PKEY_do_something` rather than `EVP_DigestDoSomething`.
-
-Except when otherwise required, avoid mixed-case names.
 
 Make sure that names do not contain spelling errors.
 

--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -252,12 +252,13 @@ have descriptive names, as do global functions. If you have a function
 that counts the number of active users, you should call that
 _count_active_users()_ or similar, you should NOT call it _cntusr()_.
 
-For getter functions returning pointers
+For getter functions returning a pointer
 and functions setting a pointer given as a parameter,
-use names containing `get0_` or `get1_`
-(rather than `get_`) and `set0_` or `set1_` (rather than `set_`)
-and `push0_` or `push1_` (rather than `push_`)
-to point out whether the value parameter has aliasing or copying semantics.
+use names containing `get0_` or `get1_` (rather than `get_`)
+or `set0_` or `set1_` (rather than `set_`)
+or `push0_` or `push1_` (rather than `push_`)
+to indicate whether the structure referred to by the pointer remains as it is
+or it is duplicated/up-ref'ed such that an additional `free()` will be needed.
 
 Use lowercase prefix like `ossl_` for internal symbols
 unless they are `static` (i.e., local to the source file).


### PR DESCRIPTION
Add a 3rd chunk of rules, taken from the list of proposed ones collected at https://github.com/openssl/openssl/issues/10725, 
focusing on names.

On this occasion clean up redundancy in the Naming chapter and re-order the rules. 