### PR TITLE
Add vote for PR 21363: fips complaince on installation

### DIFF
--- a/votes/20230706-accept-21363.txt
+++ b/votes/20230706-accept-21363.txt
@@ -1,0 +1,20 @@
+Topic: Accept PR #21363 into 3.1 subject to the normal review process
+comment: Making FIPS compliance the default for "make fips_install".  The
+         fipsinstall command still requires -pedantic for compliance.
+Proposed by: Pauli
+Issue link: https://github.com/openssl/technical-policies/pull/69
+Public: yes
+Opened: 2023-07-06
+Closed: 2023-07-07
+Accepted:  yes  (for: 6, against: 0, abstained: 0, not voted: 3)
+ONE WEEK VOTE
+
+  Dmitry     [+1]
+  Matt       [+1]
+  Pauli      [+1]
+  Tim        [  ]
+  Hugo       [+1]
+  Shane      [+1]
+  Tomas      [  ]
+  Matthias   [+1]
+  Nicola     [  ]


### PR DESCRIPTION
Note: the security policy for the 140-3 validation will mandate the `-pedantic` option as part of the installation instructions.