### PR TITLE
add clickable checkboxes for the various release checklists

### DIFF
--- a/policies/release-requirements.md
+++ b/policies/release-requirements.md
@@ -29,28 +29,28 @@ The API and ABI should be stable and the source code should be feature complete
 by the first beta pre-release. The following release requirements apply to beta
 pre-releases.
 
-- The code is functionally complete in regards to the particular release
+- [ ] The code is functionally complete in regards to the particular release
   objectives as set by OMC and OTC.
-- There is no remaining refactoring required by OMC or OTC for the release.
-- There are no remaining API changes required for the release.
+- [ ] There is no remaining refactoring required by OMC or OTC for the release.
+- [ ] There are no remaining API changes required for the release.
   _This applies only to beta releases of a major release as API changes
   are not allowed on minor releases._
-- There are no remaining API additions required for the release.
-- All issues [triaged] as regressions on the development branch from which the
+- [ ] There are no remaining API additions required for the release.
+- [ ] All issues [triaged] as regressions on the development branch from which the
   release is to be done must have a milestone assigned.
   _Regressions are considered from the previous stable release or previous
   beta release._
-- All issues or pull requests with the milestone for the beta release
+- [ ] All issues or pull requests with the milestone for the beta release
   are closed.
-- There are no outstanding untriaged Coverity issues.
-- Coveralls coverage has not decreased overall from the previous release.
-- The CI must pass on the tip of the development branch before the release
+- [ ] There are no outstanding untriaged Coverity issues.
+- [ ] Coveralls coverage has not decreased overall from the previous release.
+- [ ] The CI must pass on the tip of the development branch before the release
   commits are added to the tree, including the daily CI builds.
-- The tree must be frozen for at least 3 business days. No changes apart from
+- [ ] The tree must be frozen for at least 3 business days. No changes apart from
   regression or security fixes should be merged during the freeze.
-- For 2 days before the release there should be no changes to ensure the daily
+- [ ] For 2 days before the release there should be no changes to ensure the daily
   CI builds run on the development tree tip.
-- In case of the first beta release the OTC should explicitly approve
+- [ ] In case of the first beta release the OTC should explicitly approve
   that the source is ready for a release with a vote.
 
 Major and Minor Releases
@@ -59,20 +59,20 @@ Major and Minor Releases
 As the release comes after the beta releases there is no need to repeat the
 stability requirements as those should be held already by the beta releases.
 
-- All issues [triaged] as regressions on the development branch from which the
+- [ ] All issues [triaged] as regressions on the development branch from which the
   release is to be done must have a milestone assigned.
   _Regressions are considered from the previous stable release series._
-- All issues or pull requests with the milestone for the release are closed.
-- There are no outstanding untriaged Coverity issues.
-- Coveralls coverage has not decreased overall from the previous release from
+- [ ] All issues or pull requests with the milestone for the release are closed.
+- [ ] There are no outstanding untriaged Coverity issues.
+- [ ] Coveralls coverage has not decreased overall from the previous release from
   the particular development branch.
-- The CI must pass on the tip of the development branch before the release
+- [ ] The CI must pass on the tip of the development branch before the release
   commits are added to the tree, including the daily CI builds.
-- The tree must be frozen for at least 7 days. No changes apart from regression
+- [ ] The tree must be frozen for at least 7 days. No changes apart from regression
   or security fixes should be merged during the freeze.
-- For 2 days before the release there should be no changes to ensure the daily
+- [ ] For 2 days before the release there should be no changes to ensure the daily
   CI builds run on the development tree tip.
-- The OTC should explicitly approve that the source is ready for a release with
+- [ ] The OTC should explicitly approve that the source is ready for a release with
   a vote.
 
 Patch Releases
@@ -83,18 +83,18 @@ some simplifications as they are much more frequent and the tree stability
 requirements for the stable development branches should ensure there is
 a minimum amount of regressions in between the patch releases.
 
-- All issues [triaged] as regressions on the development branch from which the
+- [ ] All issues [triaged] as regressions on the development branch from which the
   release is to be done must have a milestone assigned.
   _Regressions are considered from the previous minor, major or patch release
   from the development branch._
-- All issues or pull requests with the milestone for the release are closed.
-- The CI must pass on the tip of the development branch before the release
+- [ ] All issues or pull requests with the milestone for the release are closed.
+- [ ] The CI must pass on the tip of the development branch before the release
   commits are added to the tree, including the daily CI builds.
-- The tree must be frozen for at least 3 business days. No changes apart from
+- [ ] The tree must be frozen for at least 3 business days. No changes apart from
   regression or security fixes should be merged during the freeze.
-- For 2 days before the release there should be no changes to ensure the daily
+- [ ] For 2 days before the release there should be no changes to ensure the daily
   CI builds run on the development tree tip.
-- Embargoed security fixes are excepted from the rule above as they cannot
+- [ ] Embargoed security fixes are excepted from the rule above as they cannot
   be merged to the public tree before the release is being prepared.
 
 Triage Process


### PR DESCRIPTION
This permits a copy/paste into an issue/project ticket without any editing.  Flagging it as a minor edit because nothing tangible has changed.