### PR TITLE
Add Doxygen comment requirement to coding style

### DIFF
--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -484,25 +484,25 @@ code as a guideline:
 
 /**
  * \file doxysample.c
- * This is an brief file description that you may add
+ * This is a brief file description that you may add
  * Subsequent lines contain more detailed information about what you will
- * find defined in this file.  Its not currently required that you add a file
- * description, but its available if you like
+ * find defined in this file.  It is not currently required that you add a file
+ * description, but its available if you like.
  */
 
  /**
   * \def MAX(x, y)
-  * document a macro that returns the maximum of two inputs
+  * document a macro that returns the maximum of two inputs.
   * \param x integer input value
-  * \param y interger input value
+  * \param y integer input value
   * \returns the maximum of x and y
   */
   #define MAX(x, y) (x > y ? x : y)
 
 /**
  * \struct foo_st
- * \brief description of the foo_st struct
- * Optional more detailed description here
+ * \brief description of the foo_st struct.
+ * Optional more detailed description here.
  */
 typedef foo_st {
     int a; /**< Describe the a field here */
@@ -511,8 +511,8 @@ typedef foo_st {
 
 
 /**
- * \brief Describe the function add briefly
- * Add a more detailed description here, like sums two inputs and returns the
+ * \brief Describe the function add briefly.
+ * Add a more detailed description here, like sums two inputs and returns the.
  * results
  * \param a - input integer to add
  * \param b - input integer to add

--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -487,7 +487,7 @@ code as a guideline:
  * This is a brief file description that you may add
  * Subsequent lines contain more detailed information about what you will
  * find defined in this file.  It is not currently required that you add a file
- * description, but its available if you like.
+ * description, but it's available if you like.
  */
 
  /**
@@ -512,8 +512,8 @@ typedef foo_st {
 
 /**
  * \brief Describe the function add briefly.
- * Add a more detailed description here, like sums two inputs and returns the.
- * results
+ * Add a more detailed description here, like sums two inputs and returns the
+ * results.
  * \param a - input integer to add
  * \param b - input integer to add
  * \returns the sum of a and b

--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -464,6 +464,11 @@ derived types. To this end, use just one data declaration per line (no
 commas for multiple data declarations). This leaves you room for a small
 comment on each item, explaining its use.
 
+In an effort to better translate our source code into documentation that is more
+easily understandable to future developers, please also consider for adding
+Doxygen style comments to any function/data structures/macros/etc that you alter
+or create in the development of patches for OpenSSL.
+
 ## Chapter 9: Macros and Enums
 
 Names of macros defining constants and labels in enums are in uppercase:

--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -469,7 +469,60 @@ easily understandable to future developers, please also consider adding
 Doxygen style comments to any function/data structures/macros/etc that you alter
 or create in the development of patches for OpenSSL.  The intent is to provide a
 more robust set of documentation for our entire code base (with particular focus
-on our internal functions and data structures).
+on our internal functions and data structures).  Please use the following sample
+code as a guideline:
+
+```c
+/*
+ * Copyright 2024 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/**
+ * \file doxysample.c
+ * This is an brief file description that you may add
+ * Subsequent lines contain more detailed information about what you will
+ * find defined in this file.  Its not currently required that you add a file
+ * description, but its available if you like
+ */
+
+ /**
+  * \def MAX(x, y)
+  * document a macro that returns the maximum of two inputs
+  * \param x integer input value
+  * \param y interger input value
+  * \returns the maximum of x and y
+  */
+  #define MAX(x, y) (x > y ? x : y)
+
+/**
+ * \struct foo_st
+ * \brief description of the foo_st struct
+ * Optional more detailed description here
+ */
+typedef foo_st {
+    int a; /**< Describe the a field here */
+    char b; /**< Describe the b field here */
+} FOO;
+
+
+/**
+ * \brief Describe the function add briefly
+ * Add a more detailed description here, like sums two inputs and returns the
+ * results
+ * \param a - input integer to add
+ * \param b - input integer to add
+ * \returns the sum of a and b
+ */
+ int add(int a, int b)
+{
+    return a + b;
+}
+```
 
 ## Chapter 9: Macros and Enums
 

--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -467,7 +467,9 @@ comment on each item, explaining its use.
 In an effort to better translate our source code into documentation that is more
 easily understandable to future developers, please also consider adding
 Doxygen style comments to any function/data structures/macros/etc that you alter
-or create in the development of patches for OpenSSL.
+or create in the development of patches for OpenSSL.  The intent is to provide a
+more robust set of documentation for our entire code base (with particular focus
+on our internal functions and data structures).
 
 ## Chapter 9: Macros and Enums
 

--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -465,7 +465,7 @@ commas for multiple data declarations). This leaves you room for a small
 comment on each item, explaining its use.
 
 In an effort to better translate our source code into documentation that is more
-easily understandable to future developers, please also consider for adding
+easily understandable to future developers, please also consider adding
 Doxygen style comments to any function/data structures/macros/etc that you alter
 or create in the development of patches for OpenSSL.
 

--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -483,7 +483,7 @@ code as a guideline:
  */
 
 /**
- * \file doxysample.c
+ * @file doxysample.c
  * This is a brief file description that you may add
  * Subsequent lines contain more detailed information about what you will
  * find defined in this file.  It is not currently required that you add a file
@@ -491,17 +491,17 @@ code as a guideline:
  */
 
  /**
-  * \def MAX(x, y)
+  * @def MAX(x, y)
   * document a macro that returns the maximum of two inputs.
-  * \param x integer input value
-  * \param y integer input value
-  * \returns the maximum of x and y
+  * @param x integer input value
+  * @param y integer input value
+  * @returns the maximum of x and y
   */
   #define MAX(x, y) (x > y ? x : y)
 
 /**
- * \struct foo_st
- * \brief description of the foo_st struct.
+ * @struct foo_st
+ * @brief description of the foo_st struct.
  * Optional more detailed description here.
  */
 typedef foo_st {


### PR DESCRIPTION
In an effort to better document our code in such a way that is condusive to future developers getting involved with our code base, I thought I would propose adding a requirement to our coding style that structures/macros/functions/etc should have Doxygen style comments added to them, so that we could build alternate docs directly from our source base.