### PR TITLE
Proposal: Allow for community reviewers to reduce PR backlog

### DIFF
--- a/policies/community-reviewers.md
+++ b/policies/community-reviewers.md
@@ -1,0 +1,39 @@
+# Community Reviewer Policy
+
+This document describes the privileges and expectations of community reviewers
+
+## Reasoning
+
+While any community member may review a PR in the OpenSSL repository, the
+recognition of community reviewers serves to create greater agency in our
+community by affording willing members the ability to have their reviews
+"count" toward the required number of reviews for inclusion in our code base.
+This also reduces the workload of those in the committer and OTC groups within
+the organization in an effort to more quickly process our PR backlog
+
+## Privileges
+
+Those community members who are in the OpenSSL reviewers group, do _not_ have
+access to modify the code base on their own (differentiating them from
+committers).  However, they enjoy the privilege of being able to preform reviews
+that are taken into account when merging, by being recognized as a review toward
+the minimum required number before a change can be merged.
+
+## Responsibilities 
+
+Community members who are in the reviewers group are expected to perform reviews
+on a regular basis.  Reviewers who do not perform a minimum of one review per
+release, can be removed from the group at the discretion of the OTC.
+
+## Nomination and Approval
+
+Community members wishing to become part of the reviewers group may petition the
+OTC by creating a pull request against this repository, making a change to the
+list below to add their name/email.  Such pull requests will be reviewed by the
+OTC, and voted on.  Reviewers wishing to join should, in the commit log of their
+pull request list reviews that they have completed prior to the opening of the
+nominating pull request, so that OTC may consider their prior work.  A minimum
+of 5 reviews is required for consideration.
+
+## OTC Reviewer list members
+


### PR DESCRIPTION
I wanted to propose the following policy change in an effort to better expidite our backlog of Pull Requests

Summary:
I'd like to create a github group within the openssl organization, called reviewers, to which community members can nominate themselves to join (and OTC can vote on), in an effort to create a larger pool of people to review outstanding PR's in such a way that our merge requirements overhead is reduced.

Details regarding the nomination process/abilities/requirements are in the policy document

One of the things that has bothered me in reviewing our backlog is the number of prs that "falls through the cracks".  We don't have the resources available to review everything in a timely fashion, so I would like to propose that we engage our community to give them additional agency to do some of this work.

By allowing community members to nominate themselves to be reviewers, we gain several advantages:

1) It allows for community members to aid in reducing the number of
   reviews people in the otc and committers groups need to do.  A
   reviewer group expands the number of people who's reviews "count"
   toward our minimal number to merge a request

2) It creates greater engagement and ownership in our communities.
   People who have the ability to affect change in our code base should
   translate into more people who want to participate