### PR TITLE
Edit links

### DIFF
--- a/policies/api-compat.md
+++ b/policies/api-compat.md
@@ -22,6 +22,6 @@ APIs and thus they are not allowed in minor releases.
 If necessary, a new API call can be added to implement the required changes in
 minor releases.
 
-[ABI]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#abi
-[API]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#api
-[minor]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#minor-release
+[ABI]: /policies/general/glossary/#abi
+[API]: /policies/general/glossary/#api
+[minor]: /policies/general/glossary/#minor-release

--- a/policies/assembler.md
+++ b/policies/assembler.md
@@ -14,6 +14,6 @@ acceptable where such updates would be allowed under the
 Where assembler optimisations are acceptable they should be implemented using
 [perlasm].
 
-[perlasm]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#perlasm
-[stable release]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#stable-release
-[stable release update policy]: https://github.com/openssl/technical-policies/blob/master/policies/stable-release-updates.md
+[perlasm]: /policies/general/glossary/#perlasm
+[stable release]: /policies/general/glossary/#stable-release
+[stable release update policy]: /policies/technical/stable-release-updates/

--- a/policies/branch-policy.md
+++ b/policies/branch-policy.md
@@ -94,4 +94,4 @@ of OpenSSL-1.1.1 are named `OpenSSL_1_1_1<fix-letter(s)>`.
 The exact times when the future major and minor branches are created are
 undefined by the policy as that is an OMC responsibility to decide.
 
-[stable release update policy]: https://github.com/openssl/technical-policies/blob/master/policies/stable-release-updates.md
+[stable release update policy]: /policies/technical/stable-release-updates/

--- a/policies/documentation-policy.md
+++ b/policies/documentation-policy.md
@@ -127,6 +127,6 @@ comments than less or none.  Code that you've just written that is
 _obvious_ will not necessarily be to someone else two years later.
 
 
-[CHANGES]: https://github.com/openssl/general-policies/blob/master/policies/definitions.md#changes
-[NEWS]: https://github.com/openssl/general-policies/blob/master/policies/definitions.md#news
-[LDP]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#ldp
+[CHANGES]: /policies/general/glossary/#changes
+[NEWS]: /policies/general/glossary/#news
+[LDP]: /policies/general/glossary/#ldp

--- a/policies/release-requirements.md
+++ b/policies/release-requirements.md
@@ -123,9 +123,9 @@ major or minor releases.
 For example the responsibility to follow the release requirements can be
 delegated by the OTC to the person (or the team) preparing the release.
 
-[alpha]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#alpha-release
-[beta]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#beta-release
-[major]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#major-release
-[minor]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#minor-release
-[patch]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#patch-release
+[alpha]: /policies/general/glossary/#alpha-release
+[beta]: /policies/general/glossary/#beta-release
+[major]: /policies/general/glossary/#major-release
+[minor]: /policies/general/glossary/#minor-release
+[patch]: /policies/general/glossary/#patch-release
 [triaged]: #triage-process

--- a/policies/stable-release-updates.md
+++ b/policies/stable-release-updates.md
@@ -52,7 +52,7 @@ A **bug fix** is **not**:
 - refactoring
 - addressing deviations from the [coding style policy].
 
-[coding style policy]: https://github.com/openssl/technical-policies/blob/master/policies/coding-style.md
+[coding style policy]: /policies/technical/coding-style/
 
 An **end-user documentation** is:
 

--- a/policies/testing.md
+++ b/policies/testing.md
@@ -109,8 +109,8 @@ Where performance fixes are implemented consideration should be given to whether
 we need to add a performance test to the performance testing suite.
 
 
-[CHANGES]: https://github.com/openssl/general-policies/blob/master/policies/definitions.md#changes
-[CI]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#ci
-[NEWS]: https://github.com/openssl/general-policies/blob/master/policies/definitions.md#news
-[OTC]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#otc
-[stable]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#stable-release
+[CHANGES]: /policies/general/glossary/#changes
+[CI]: /policies/general/glossary/#ci
+[NEWS]: /policies/general/glossary/#news
+[OTC]: /policies/general/glossary/#otc
+[stable]: /policies/general/glossary/#stable-release

--- a/policies/voting-procedure.md
+++ b/policies/voting-procedure.md
@@ -72,5 +72,5 @@ The issue is then closed. In case the vote is in a pull request for a policy
 change and the vote passed the pull request for the policy change is squashed
 and merged into the repository.
 
-[OTC]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#otc
-[OpenSSL Project mailing list]: https://mta.openssl.org/mailman/listinfo/openssl-project
+[OTC]: /policies/general/glossary/#otc
+[OpenSSL Project mailing list]: https://groups.google.com/a/openssl.org/g/openssl-project


### PR DESCRIPTION
`Technical Policies` section on `openssl-library.org` is generated from this repository. Therefore links in these documents must be adapted to work primarily on the website.