### PR TITLE
- update chapter 14 w.r.t. switch from c90 to c99

### DIFF
--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -706,9 +706,10 @@ it portable enough to meet our multi-platform support goals.
 ## Chapter 14: Portability
 
 To maximise portability the version of C defined in ISO/IEC 9899:1999
-should be used. This is more commonly referred to as C99. The C99 should
-be used on master branch. Code which is intended to be backported to
-3.5 and earlier branches should use ISO/IEC 9899:1990 (a.k.a. C90).
+should be used. This is more commonly referred to as C99. C99 can be
+used on code targeting 3.6 and newer branches. Code which is intended
+to be backported to 3.5 and earlier branches should use
+ISO/IEC 9899:1990 (a.k.a. C90).
 
 ## Chapter 15: Expressions
 

--- a/policies/coding-style.md
+++ b/policies/coding-style.md
@@ -705,10 +705,10 @@ it portable enough to meet our multi-platform support goals.
 
 ## Chapter 14: Portability
 
-To maximise portability the version of C defined in ISO/IEC 9899:1990
-should be used. This is more commonly referred to as C90. ISO/IEC 9899:1999
-(also known as C99) is not supported on some platforms that OpenSSL is
-used on and therefore should be avoided.
+To maximise portability the version of C defined in ISO/IEC 9899:1999
+should be used. This is more commonly referred to as C99. The C99 should
+be used on master branch. Code which is intended to be backported to
+3.5 and earlier branches should use ISO/IEC 9899:1990 (a.k.a. C90).
 
 ## Chapter 15: Expressions
 


### PR DESCRIPTION
not sure if it follows the proper update process.

back in May/Jun we agreed to use c99. If I remember correct we never discussed if C99 should be allowed on release branches. I feel we branches 3.5 and older should stick to c90 master and 3.6 can should use c99.